### PR TITLE
new breakpoint fixed

### DIFF
--- a/src/components/heroSection.js
+++ b/src/components/heroSection.js
@@ -64,7 +64,7 @@ const HeroSection = () => {
           <img src="assets/images/hero_pc.jpg" alt="Hero Desktop" className="w-full  object-cover" />
         </div>
       </div>
-      <div className="relative z-10 flex items-center justify-center h-full text-white px-8 pt-[350px] md:pt-[650px] lg:pt-[70px] xl:pt-[130px] 2xl:pt-[180px] 3xl:pt-[180px] 4xl:pt-[250px] 5xl:pt-[450px]">
+      <div className="relative z-10 flex items-center justify-center h-full text-white px-8 pt-[350px] md:pt-[650px] lg:pt-[70px] xl:pt-[130px] 2xl:pt-[180px] 3xl:pt-[180px]  3.5xl:pt-[270px] 4xl:pt-[250px] 5xl:pt-[450px]">
         <div className="flex flex-col lg:flex-row items-center justify-between w-full max-w-5xl space-y-8 md:space-y-0 md:space-x-8">
           <div className="flex flex-col space-y-4 text-left max-w-sm md:max-w-lg lg:max-w-sm">
             <h1 className="text-4xl md:text-6xl font-bold">Start your scholarship</h1>

--- a/src/components/uberSection.js
+++ b/src/components/uberSection.js
@@ -1,6 +1,6 @@
 const UberSection = () => {
   return (
-    <section className="bg-uberColor py-12 px-4 lg:px-8 mt-[-300px] lg:mt-[10px] xl:mt-[80px] 1.5xl:mt-[162px] 3xl:mt-[196px] 4xl:mt-[290px] 5xl:mt-[420px]">
+    <section className="bg-uberColor py-12 px-4 lg:px-8 mt-[-300px] lg:mt-[10px] xl:mt-[80px] xxl:mt-[60px] 1.5xl:mt-[162px] 3xl:mt-[196px]  3.5xl:mt-[160px] 4xl:mt-[290px] 5xl:mt-[420px]">
       <div className="max-w-6xl mx-auto text-center pt-[400px] md:pt-[350px] lg:pt-0">
         <div className="flex flex-col justify-center items-center">
           <h2 className="text-3xl md:text-4xl font-bold text-black">The Uber for Scholarships</h2>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -24,8 +24,10 @@ export default {
       },
       screens: {
         'xsm' : '375px',  
+        'xxl': '1107px',
         '1.5xl': '1440px',
         '3xl': '1600px',
+        '3.5xl': '1710px',
         '4xl': '1920px',
         '5xl': '2560px',
       },


### PR DESCRIPTION
This pull request includes updates to the `src/components/heroSection.js`, `src/components/uberSection.js`, and `tailwind.config.mjs` files to add new responsive breakpoints and adjust padding and margin values for better layout control.

### Responsive Breakpoints and Layout Adjustments:

* [`src/components/heroSection.js`](diffhunk://#diff-413c6f9b12e431ebcca353e35a0ce73971736a5f63696ceb5f6f71d55a7716d5L67-R67): Added a new breakpoint `3.5xl` with a padding top value of `270px` to the hero section layout.
* [`src/components/uberSection.js`](diffhunk://#diff-38a9f57a97e79ff3b8db3afa798f1475a99517242c975a43561758b76f720a60L3-R3): Introduced new breakpoints `xxl` and `3.5xl` with margin top values of `60px` and `160px` respectively to the Uber section layout.
* [`tailwind.config.mjs`](diffhunk://#diff-aff1492b58cdb20ff9554dba377672d03b18f6f9ba80a56ff7d4cc6e60a4ae07R27-R30): Added new responsive breakpoints `xxl` at `1107px` and `3.5xl` at `1710px` to the Tailwind CSS configuration.